### PR TITLE
Support for more client headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+# GoLand / IntelliJ
+.idea

--- a/api/get_ip.go
+++ b/api/get_ip.go
@@ -35,7 +35,7 @@ func GetIP(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		// list.  We do this because this is always the *origin* IP address, which
 		// is the *true* IP of the user.  For more information on this, see the
 		// Wikipedia page: https://en.wikipedia.org/wiki/X-Forwarded-For
-		ip = net.ParseIP(strings.Split(r.Header.Get("i"), ",")[0])
+		ip = net.ParseIP(strings.Split(r.Header.Get("X-Forwarded-For"), ",")[0])
 	}
 
 	if ip == nil {

--- a/main.go
+++ b/main.go
@@ -8,12 +8,13 @@
 package main
 
 import (
-	"github.com/julienschmidt/httprouter"
-	"github.com/rdegges/ipify-api/api"
-	"github.com/rs/cors"
 	"log"
 	"net/http"
 	"os"
+
+	"github.com/DNSFilter/ipify-api/api"
+	"github.com/julienschmidt/httprouter"
+	"github.com/rs/cors"
 )
 
 // main launches our web server which runs indefinitely.
@@ -39,5 +40,4 @@ func main() {
 
 	log.Println("Starting HTTP server on port:", port)
 	log.Fatal(http.ListenAndServe(":"+port, handler))
-
 }


### PR DESCRIPTION
Added support to handle CF-Connecting-IP header and if no header is set at all, fallback to requesting IP
Changed import URLs to DNSFilter ones